### PR TITLE
Add tox.ini for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy, pypy3
+
+[testenv]
+deps = pytest
+       pytest-cov
+commands = py.test {posargs:--cov=funcsigs --cov-report=term-missing  tests/}


### PR DESCRIPTION
```
$ pip install tox
...
$ tox
...
ERROR:   py26: commands failed
  py27: commands succeeded
  py32: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  pypy: commands succeeded
ERROR:   pypy3: commands failed
```
