### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ To obtain a signature object, pass the target function to the
 For the details of the signature object, refer to the either the package of
 standard library documentation.
 
-Compatability
+Compatibility
 -------------
 
 The ``funcsigs`` backport has been tested against:
@@ -41,10 +41,10 @@ The ``funcsigs`` backport has been tested against:
 
 Continuous integration testing is provided by `Travis CI`_.
 
-Under Python 2.x there is a compatability issue when a function is assigned to
+Under Python 2.x there is a compatibility issue when a function is assigned to
 the ``__wrapped__`` property of a class after it has been constructed.
 Similiarily there under PyPy directly passing the ``__call__`` method of a
-builtin is also a compatability issues.  Otherwise the functionality is
+builtin is also a compatibility issues.  Otherwise the functionality is
 believed to be uniform between both Python2 and Python3.
 
 Issues


### PR DESCRIPTION
compat**a**bility -> compat**i**bility
