### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ work is distributed under the `Apache License Version 2.0`_.
 .. _GitHub: https://github.com/aliles/funcsigs
 .. _PSF License Agreement: http://docs.python.org/3/license.html#terms-and-conditions-for-accessing-or-otherwise-using-python
 .. _Travis CI: http://travis-ci.org/
-.. _Read The Docs: http://funcsigs.readthedocs.org/
+.. _Read The Docs: https://funcsigs.readthedocs.io/
 .. _PEP 362: http://www.python.org/dev/peps/pep-0362/
 .. _inspect: http://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object
 .. _issues system: https://github.com/alies/funcsigs/issues

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     zip_safe=False,
     author="Aaron Iles",
     author_email="aaron.iles@gmail.com",
-    url="http://funcsigs.readthedocs.org",
+    url="https://funcsigs.readthedocs.io",
     description="Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+",
     long_description=open('README.rst').read(),
     # long_description=load_rst(),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
